### PR TITLE
support fetching manifest file with credentials

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="apple-touch-icon" href="icon.png">
-    <link rel="manifest" href="manifest.json">
+    <link rel="manifest" href="manifest.json" crossorigin="use-credentials">
     <link href="public/css/kclient.css" rel="stylesheet">
     <script src="audio/socket.io/socket.io.js"></script>
     <script src="public/js/pcm-player.js"></script>


### PR DESCRIPTION
If the manifest requires credentials to fetch, the `crossorigin` attribute must be set to `use-credentials`, even if the manifest file is in the same origin as the current page.

see https://developer.mozilla.org/en-US/docs/Web/Manifest#deploying_a_manifest

Without the attribute:
<img width="886" alt="Screenshot 2023-09-17 at 10 54 30 AM" src="https://github.com/linuxserver/kclient/assets/283482/6f648b30-c989-4cb8-a7a0-9cb5fe8b8a0b">

With the attribute:
<img width="886" alt="Screenshot 2023-09-17 at 11 00 46 AM" src="https://github.com/linuxserver/kclient/assets/283482/65f6fa19-1db1-4c68-b624-51aa212c7ad9">
