### PR TITLE
feat: support websockify behind a proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,13 @@
 //// Env variables ////
 var CUSTOM_USER = process.env.CUSTOM_USER || 'abc';
 var PASSWORD = process.env.PASSWORD || 'abc';
+var PRE_PATH = process.env.PRE_PATH || '/';
 var SUBFOLDER = process.env.SUBFOLDER || '/';
 var TITLE = process.env.TITLE || 'KasmVNC Client';
 var FM_HOME = process.env.FM_HOME || '/config';
 var PATH;
-if (SUBFOLDER != '/') {
-  PATH = '&path=' + SUBFOLDER.substring(1) + 'websockify'
+if (PRE_PATH != '/' || SUBFOLDER != '/') {
+  PATH = '&path=' + PRE_PATH.substring(1) + SUBFOLDER.substring(1) + 'websockify'
 } else {
   PATH = false;
 }


### PR DESCRIPTION
If the whole nodejs server is behind a proxy like nginx, this change makes the websockify work well. For example, a request is sent to `http://exmaple.com/myvnc`, nginx rewrites the path from `/myvnc` to `/`, then proxy-passes the request to localhost:6900. Previously, `vnc/index.html` wrongly tries to connect `ws://example.com/websockify`, which is forbidden by the nginx. After setting `PRE_PATH` to `/myvnc/`, the URL is `ws://example.com/myvnc/websockify`, then can be processed by nginx. If the whole nodejs server is not behind a proxy, without setting `PRE_PATH`, the `index.js` behaves like before.